### PR TITLE
Notes confirm on clear, add edit functionality

### DIFF
--- a/aliases/notes.sh
+++ b/aliases/notes.sh
@@ -10,8 +10,15 @@ note () {
         # If no arguments, print file.
         cat "$HOME/Documents/.notes"
     elif [[ "$1" == "-c" ]]; then
-        # Clear contents of the file.
-        printf "%s" > "$HOME/Documents/.notes"
+        read -k 1 -r confirm\?"Are you sure? (y/N) "
+        echo
+        if [[ $confirm =~ ^[Yy]$ ]]; then
+            # Clear contents of the file.
+            printf "%s" > "$HOME/Documents/.notes"
+        fi
+    elif [[ "$1" == "-e" ]]; then
+        # Edit contents of the file.
+        vim "$HOME/Documents/.notes"
     else
         # Add all arguments to file.
         printf "%s\n" "$*" >> "$HOME/Documents/.notes"


### PR DESCRIPTION
Using `note -c` to clear notes now asks for user confirmation. Added option `note -e` to edit the notes file with vim.